### PR TITLE
Added [FromQuery] to ReporteController Get method.

### DIFF
--- a/ITSC_Proyecto_Final/Controllers/ReporteController.cs
+++ b/ITSC_Proyecto_Final/Controllers/ReporteController.cs
@@ -18,9 +18,11 @@ public class ReporteController : ControllerBase
 
     // GET all action
     [HttpGet]
-    public IEnumerable<Reporte> Get(Filtro filtro)
+    public IEnumerable<Reporte> Get([FromQuery] Filtro filtro)
     {
         return _service.GetReportes(filtro);
     }
+
+    
 
 }


### PR DESCRIPTION
We needed to pass the arguments via query string
instead of the body of the request, so we added the
[FromQuery] attribute to the Get method to change.